### PR TITLE
Attempt to emit a custom event at the end of `__init__` to enforce it runs on all hooks

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,3 +10,4 @@ parts:
   charm:
     prime:
       - files/*yaml
+    charm-python-packages: [setuptools, pip]  # Fixes install of some packages

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,12 +24,7 @@ class CustomEvent(HookEvent):
         self.message = message
 
 
-# class CharmCustomEvents(ObjectEvents):
-#     custom_event = EventSource(CustomEvent)
-
-
 class Operator(CharmBase):
-    # custom_events = CharmCustomEvents()
     _stored = StoredState()
 
     def __init__(self, *args):
@@ -65,17 +60,13 @@ class Operator(CharmBase):
 
         self.custom_event = CustomEvent
 
-        # self.on.define_event("custom_event", self.custom_events.custom_event)
         self.on.define_event("custom_event", self.custom_event)
         self.framework.observe(self.on.custom_event, self._handle_custom_event)
-        # self.custom_events.custom_event.emit("from __init__")
-        # self.custom_event.emit()
+
         self.on.custom_event.emit()
 
-    # def _handle_custom_event(self, event, message):
     def _handle_custom_event(self, event):
         self.log.error("HANDLING CUSTOM EVENT!")
-        # self.log.error(f"message: '{message}")
 
     def send_info(self, event):
         if self.interfaces["kubeflow-profiles"]:
@@ -87,8 +78,6 @@ class Operator(CharmBase):
             )
 
     def main(self, event):
-        # self.custom_events.custom_event.emit("from set_pod_spec")
-        # self.custom_event.emit()
         self.on.custom_event.emit()
 
         try:


### PR DESCRIPTION
For a case where we want to run some code after any hook (including those we don't explicitly add handlers for), this gives an example of adding a "finalizer" event that will run after each hook.  

Oddly when I tested this quickly I don't remember it causing an infinite loop of "call custom handler", although probably there's an if statement we could add in `__init__` to make that certain.  