### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,6 +3,7 @@
 name: kubeflow-profiles
 summary: Kubeflow Profiles and Access Management
 description: Kubeflow Profiles and Access Management
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   profile-image:


### PR DESCRIPTION
This PR addresses GH-425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.