### PR TITLE
Beta test new release charm action

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   lint:
@@ -10,28 +12,28 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      - name: Install dependencies
+        run: sudo apt-get install python3-pip tox
 
-    - name: Lint code
-      run: tox -e lint
+      - name: Lint code
+        run: tox -e lint
 
   unit:
     name: Unit Test
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: sudo apt-get install python3-pip tox
+      - name: Install dependencies
+        run: sudo apt-get install python3-pip tox
 
-    - name: Run unit tests
-      run: tox -e unit
+      - name: Run unit tests
+        run: tox -e unit
 
   deploy:
     name: Integration Test
@@ -42,9 +44,9 @@ jobs:
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
-            provider: microk8s
-            channel: 1.21/stable
-            charmcraft-channel: latest/candidate
+          provider: microk8s
+          channel: 1.21/stable
+          charmcraft-channel: latest/candidate
       # TODO: Remove once the actions-operator does this automatically
       - name: Configure kubectl
         run: |
@@ -73,4 +75,3 @@ jobs:
       - name: Get operator logs
         run: kubectl logs --tail 100 -ntesting -ljuju-operator
         if: failure()
-

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ jobs:
     if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
     steps:
       - uses: actions/checkout@v2
-      - uses: canonical/charmhub-upload-action@0.2.0
+      - uses: canonical/charming-actions/upload-charm@1.0.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          charm-path: ./
-          charmcraft-channel: latest/edge
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          channel: latest/edge

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release charm to other tracks and channels
+
+on:
+  workflow_dispatch:
+    inputs:
+      destination-channel:
+        description: 'Destination Channel'
+        required: true
+      origin-channel:
+        description: 'Origin Channel'
+        required: false
+      rev:
+        description: 'Revision number'
+        required: false
+
+jobs:
+  promote-charm:
+    name: Promote charm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Release charm to channel
+        uses: canonical/charming-actions/release-charm@promote-charm
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          destination-channel: ${{ github.event.inputs.destination-channel }}
+          origin-channel: ${{ github.event.inputs.origin-channel }}
+          revision: ${{ github.event.inputs.rev }}

--- a/src/charm.py
+++ b/src/charm.py
@@ -194,7 +194,7 @@ class Operator(CharmBase):
 
 
 class CheckFailed(Exception):
-    """ Raise this exception if one of the checks in main fails. """
+    """Raise this exception if one of the checks in main fails."""
 
     def __init__(self, msg: str, status_type=None):
         super().__init__()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-black==20.8b1
+black
 flake8
 flake8-copyright<0.3
 lightkube<0.9

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 [testenv:lint]
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
-    black --check {toxinidir}/src {toxinidir}/tests
+    black --check --diff {toxinidir}/src {toxinidir}/tests
 
 [testenv:integration]
 deps =


### PR DESCRIPTION
Add new release charm action. Update publish action to use `upload-charm` as the release action need the release info from that action. 
It's using the release charm action from [promote-charm branch](https://github.com/canonical/charming-actions/tree/promote-charm). This would be updated in the future to use stable version