### PR TITLE
feat: enable publishing on-demand from main

### DIFF
--- a/.github/workflows/get-charm-paths.sh
+++ b/.github/workflows/get-charm-paths.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+# Finds the charms in this repo, outputing them as JSON
+# Will return one of:
+# * the relative paths of the directories listed in `./charms`, if that directory exists
+# * "./", if the root directory has a "metadata.yaml" file
+# * otherwise, error
+#
+# Modifed from: https://stackoverflow.com/questions/63517732/github-actions-build-matrix-for-lambda-functions/63736071#63736071
+CHARMS_DIR="./charms"
+if [ -d "$CHARMS_DIR" ];
+then
+	CHARM_PATHS=$(find $CHARMS_DIR -maxdepth 1 -type d -not -path '*/\.*' -not -path "$CHARMS_DIR")
+else
+	if [ -f "./metadata.yaml" ]
+	then
+		CHARM_PATHS="./"
+	else
+		echo "Cannot find valid charm directories - aborting"
+		exit 1
+	fi
+fi
+
+# Convert output to JSON string format
+# { charm_paths: [...] }
+CHARM_PATHS_LIST=$(echo "$CHARM_PATHS" | jq -c --slurp --raw-input 'split("\n")[:-1]')
+
+echo "Found CHARM_PATHS_LIST: $CHARM_PATHS_LIST"
+
+echo "::set-output name=CHARM_PATHS_LIST::$CHARM_PATHS_LIST"

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -1,4 +1,4 @@
-name: Test and publish to branch
+name: On Pull Request
 
 # On pull_request, we:
 # * always publish to charmhub at latest/edge/branchname
@@ -20,4 +20,4 @@ jobs:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
     secrets:
-      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+      CHARMCRAFT_CREDENTIALS: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge if tests passed
+name: On Push
 
 # On push to a "special" branch, we:
 # * always publish to charmhub at latest/edge/branchname
@@ -28,4 +28,4 @@ jobs:
     needs: tests
     uses: ./.github/workflows/publish.yaml
     secrets:
-      charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+      CHARMCRAFT_CREDENTIALS: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,28 +1,82 @@
-# reusable workflow triggered by other actions
+# reusable workflow for publishing all charms in this repo
 name: Publish
 
 on:
   workflow_call:
     secrets:
-      charmcraft-credentials:
+      CHARMCRAFT_CREDENTIALS:
         required: true
+  workflow_dispatch:
+    inputs:
+      # TODO: Implement this
+      # source_github_branch:
+      #   description: Source branch to publish
+      #   required: false
+      #   default: 'main'
+      destination_channel:
+        description: CharmHub channel to publish to
+        required: false
+        default: 'latest/edge'
 
 jobs:
+  get-charm-paths:
+    name: Generate the Charm Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get paths for all charms in repo
+        id: get-charm-paths
+        run: bash .github/workflows/get-charm-paths.sh
+
 
   publish-charm:
     name: Publish Charm
     runs-on: ubuntu-latest
+    needs: get-charm-paths
+    strategy:
+      fail-fast: false
+      matrix:
+        charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.0.0-rc
-        id: channel
+        id: select-channel
+        if: ${{ inputs.destination_channel == '' }}
+
+      # Combine inputs from different sources to a single canonical value so later steps don't
+      # need logic for picking the right one
+      - name: Parse and combine inputs
+        id: parse-inputs
+        run: |
+          # destination_channel
+          destination_channel="${{ inputs.destination_channel || steps.select-channel.outputs.name }}"
+          echo "setting output of destination_channel=$destination_channel"
+          echo "::set-output name=destination_channel::$destination_channel"
+
+          # tag_prefix
+          # if charm_path = ./ --> tag_prefix = '' (null)
+          # if charm_path != ./some-charm (eg: a charm in a ./charms dir) --> tag_prefix = 'some-charm'
+          if [ ${{ matrix.charm-path }} == './' ]; then
+            tag_prefix=''
+          else
+            tag_prefix=$(basename ${{ matrix.charm-path }} )
+          fi
+          echo "setting output of tag_prefix=$tag_prefix"
+          echo "::set-output name=tag_prefix::$tag_prefix"
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          charm-path: ${{ matrix.charm-path }}
+          channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+          tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}


### PR DESCRIPTION
Similar to canonical/kfp-operators#93, this implements an on-demand publishing of the default branch to charmhub via a workflow_dispatch.  This is done from the github Actions tab for the publish action.