### PR TITLE
chore: oci image version bump 1.6.0-rc.2 -> 1.6.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,12 +10,12 @@ resources:
     type: oci-image
     description: Profile controller image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.6.0-rc.2
+    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.6.0
   kfam-image:
     type: oci-image
     description: Access Management image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.6.0-rc.2
+    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.6.0
 provides:
   kubeflow-profiles:
     interface: k8s-service


### PR DESCRIPTION
Version bump to 1.6.0 release image

NOTE: this PR depends on the latest image tag specified in [kubeflow/manifests](https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/admission-webhook/upstream