### PR TITLE
Expanded user creation action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -14,9 +14,6 @@ create-profile:
 initialise-profile:
   description: Apply configuration to an existing profile
   params:
-   auth-username:
-     type: string
-     description: the username of the existing authenticated user
-   profile-name:
-     type: string
-     description: the name of the new profile to be created
+    profilename:
+      type: string
+      description: the name of the new profile to be created

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,15 +1,15 @@
 create-profile:
- description: Create a new profile under an existing authenticated user and apply configurations to the profile.
- params:
-   authusername:
-     type: string
-     description: the username of the existing authenticated user
-   profilename:
-     type: string
-     description: the name of the new profile to be created
-   resourcequota:
-     type: string
-     description: (Optional) resource quota for the new profile
+  description: Create a new profile under an existing authenticated user and apply configurations to the profile.
+  params:
+    authusername:
+      type: string
+      description: the username of the existing authenticated user
+    profilename:
+      type: string
+      description: the name of the new profile to be created
+    resourcequota:
+      type: string
+      description: (Optional) resource quota for the new profile
 
 initialise-profile:
   description: Apply configuration to an existing profile

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -267,7 +267,9 @@ sniffio==1.3.0
 stack-data==0.6.2
     # via ipython
 tenacity==8.1.0
-    # via -r ./requirements-integration.in
+    # via
+    #   -r ./requirements-integration.in
+    #   -r ./requirements.txt
 theblues==0.5.2
     # via juju
 toml==0.10.2

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -137,6 +137,8 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
+tenacity==8.1.0
+    # via -r ./requirements.txt
 tomli==2.0.1
     # via pytest
 urllib3==1.26.13

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ oci-image
 serialized-data-interface
 lightkube
 charmed-kubeflow-chisme
+tenacity

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,6 +75,8 @@ sniffio==1.3.0
     #   anyio
     #   httpcore
     #   httpx
+tenacity==8.1.0
+    # via -r ./requirements.in
 urllib3==1.26.13
     # via requests
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Unit tests. Harness and Mocks are defined in test_operator_fixtures.py."""
+import json
 from unittest.mock import MagicMock, patch
 
 from ops.charm import ActionEvent
@@ -132,7 +133,18 @@ def test_on_create_profile_action(
 
     auth_username = "admin"
     profile_name = "username"
-    resource_quota = "resourcequota"
+    resource_quota = """
+    {
+    "hard": {
+        "cpu": "2",
+        "memory": "2Gi",
+        "requests.nvidia.com/gpu": "1",
+        "persistentvolumeclaims": "1",
+        "requests.storage": "5Gi"
+                }
+        }
+    """
+    formatted_quota = json.loads(resource_quota)
     event = MagicMock(spec=ActionEvent)
     event.params = {
         "authusername": auth_username,
@@ -141,4 +153,4 @@ def test_on_create_profile_action(
     }
     harness.charm.on_create_profile_action(event)
 
-    create_profile.assert_called_with(auth_username, profile_name, resource_quota)
+    create_profile.assert_called_with(auth_username, profile_name, formatted_quota)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -4,6 +4,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Secret
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, WaitingStatus
 
@@ -12,6 +14,7 @@ from charm import KubeflowProfilesOperator
 from .test_operator_fixtures import (  # noqa F401
     harness,
     mocked_kubernetes_service_patcher,
+    mocked_lightkube_client,
     mocked_resource_handler,
 )
 
@@ -174,3 +177,42 @@ def test_on_initialise_profile_action(
     harness.charm.on_initialise_profile_action(event)
 
     configure_profile.assert_called_with(profile_name)
+
+
+def test_copy_seldon_secret(
+    harness,  # noqa F811
+    mocked_kubernetes_service_patcher,  # noqa F811
+    mocked_resource_handler,  # noqa F811
+    mocked_lightkube_client,  # noqa F811
+):
+    """Test that seldon secret is copied to the profile's namespace with the correct values."""
+    profile_name = "username"
+    seldon_secret = Secret(
+        metadata=ObjectMeta(name="mlflow-server-seldon-init-container-s3-credentials"),
+        kind="Secret",
+        apiVersion="v1",
+        data={
+            "RCLONE_CONFIG_S3_TYPE": "s3",
+            "RCLONE_CONFIG_S3_PROVIDER": "minio",
+            "RCLONE_CONFIG_S3_ACCESS_KEY_ID": "minio",
+            "RCLONE_CONFIG_S3_SECRET_ACCESS_KEY": "minio123",
+            "RCLONE_CONFIG_S3_ENDPOINT": "http://minio.kubeflow.svc.cluster.local:9000",
+            "RCLONE_CONFIG_S3_ENV_AUTH": "false",
+        },
+        type="Opaque",
+    )
+    mocked_lightkube_client.get.return_value = seldon_secret
+    harness.begin()
+    harness.set_leader(True)
+    harness.charm.k8s_resource_handler.lightkube_client = mocked_lightkube_client
+    harness.charm._copy_seldon_secret(profile_name)
+    harness.charm.k8s_resource_handler.lightkube_client.create.assert_called_with(
+        Secret(
+            metadata=ObjectMeta(name="seldon-init-container-secret"),
+            kind="Secret",
+            apiVersion=seldon_secret.apiVersion,
+            data=seldon_secret.data,
+            type=seldon_secret.type,
+        ),
+        namespace=profile_name,
+    )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -149,8 +149,28 @@ def test_on_create_profile_action(
     event.params = {
         "authusername": auth_username,
         "profilename": profile_name,
-        "resourcequota": resource_quota,
+        "resourcequota": formatted_quota,
     }
     harness.charm.on_create_profile_action(event)
 
     create_profile.assert_called_with(auth_username, profile_name, formatted_quota)
+
+
+@patch.object(KubeflowProfilesOperator, "configure_profile")
+def test_on_initialise_profile_action(
+    configure_profile,
+    harness,  # noqa F811
+    mocked_kubernetes_service_patcher,  # noqa F811
+    mocked_resource_handler,  # noqa F811
+):
+    """Test that configure_profile method is called on initialise-profile action."""
+    harness.begin()
+    harness.set_leader(True)
+    event = MagicMock(spec=ActionEvent)
+    profile_name = "username"
+    event.params = {
+        "profilename": profile_name,
+    }
+    harness.charm.on_initialise_profile_action(event)
+
+    configure_profile.assert_called_with(profile_name)

--- a/tests/unit/test_operator_fixtures.py
+++ b/tests/unit/test_operator_fixtures.py
@@ -33,3 +33,10 @@ def mocked_resource_handler(mocker):
     mocked_resource_handler = mocker.patch("charm.KRH")
     mocked_resource_handler.return_value = MagicMock()
     yield mocked_resource_handler
+
+
+@pytest.fixture()
+def mocked_lightkube_client(mocker, mocked_resource_handler):
+    """Prevents lightkube clients from being created, returning a mock instead."""
+    mocked_resource_handler.lightkube_client = MagicMock()
+    yield mocked_resource_handler.lightkube_client


### PR DESCRIPTION
## Summary:
- update action handler to include resource quota
- update create-profile action unit and integration tests accordingly
- wait for profile namespace to be created in create_profile method before applying configurations
- implement initialise-profile action handler
- unit test for initialise-profile action
- add method for seldon-init-container-secret configuration and call it in configure_profile method
- unit test for copy_seldon_secret