### PR TITLE
ci: k8s version bump 1.2x -> 1.24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.22/stable
+          channel: 1.24/stable
           # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
           bootstrap-options: "--agent-version=2.9.34"
           charmcraft-channel: latest/candidate


### PR DESCRIPTION
[skip ci] ci: k8s version bump 1.2x -> 1.24