### PR TITLE
Refactor event handling to fix stuck application issues

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,13 +63,6 @@ class KubeflowProfilesOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._k8s_resource_handler = None
 
-        # setup events to be handled by main event handler
-        self.framework.observe(self.on.upgrade_charm, self._on_event)
-        self.framework.observe(self.on.config_changed, self._on_event)
-
-        for rel in self.model.relations.keys():
-            self.framework.observe(self.on[rel].relation_changed, self._on_event)
-
         # setup events to be handled by specific event handlers
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.remove, self._on_remove)
@@ -82,6 +75,13 @@ class KubeflowProfilesOperator(CharmBase):
         self.framework.observe(
             self.on.initialise_profile_action, self.on_initialise_profile_action
         )
+
+        # setup events to be handled by main event handler
+        self.framework.observe(self.on.upgrade_charm, self._on_event)
+        self.framework.observe(self.on.config_changed, self._on_event)
+
+        for rel in self.model.relations.keys():
+            self.framework.observe(self.on[rel].relation_changed, self._on_event)
 
     @property
     def profiles_container(self):

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -71,7 +71,8 @@ def test_no_relation(
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == ActiveStatus("")
 
-def test_different_events_sequence_scenario(
+
+def test_kfam_pebble_ready_first_scenario(
     harness,  # noqa F811
     mocked_kubernetes_service_patcher,  # noqa F811
     mocked_resource_handler,  # noqa F811
@@ -83,6 +84,35 @@ def test_different_events_sequence_scenario(
     harness.charm.on.install.emit()
     harness.container_pebble_ready("kubeflow-profiles")
     assert harness.charm.model.unit.status == ActiveStatus("")
+
+
+def test_profiles_pebble_ready_first_scenario(
+    harness,  # noqa F811
+    mocked_kubernetes_service_patcher,  # noqa F811
+    mocked_resource_handler,  # noqa F811
+):
+    """Test profiles pebble ready then install then kfam pebble ready reach Active."""
+    harness.set_leader(True)
+    harness.begin()
+    harness.container_pebble_ready("kubeflow-profiles")
+    harness.charm.on.install.emit()
+    harness.container_pebble_ready("kubeflow-kfam")
+    assert harness.charm.model.unit.status == ActiveStatus("")
+
+
+def test_install_first_scenario(
+    harness,  # noqa F811
+    mocked_kubernetes_service_patcher,  # noqa F811
+    mocked_resource_handler,  # noqa F811
+):
+    """Test install then kfam pebble ready then profiles pebble ready reach Active."""
+    harness.set_leader(True)
+    harness.begin()
+    harness.charm.on.install.emit()
+    harness.container_pebble_ready("kubeflow-kfam")
+    harness.container_pebble_ready("kubeflow-profiles")
+    assert harness.charm.model.unit.status == ActiveStatus("")
+
 
 def test_profiles_pebble_layer(
     harness,  # noqa F811

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -71,6 +71,18 @@ def test_no_relation(
     harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == ActiveStatus("")
 
+def test_different_events_sequence_scenario(
+    harness,  # noqa F811
+    mocked_kubernetes_service_patcher,  # noqa F811
+    mocked_resource_handler,  # noqa F811
+):
+    """Test kfam pebble ready then install then profiles pebble ready."""
+    harness.set_leader(True)
+    harness.begin()
+    harness.container_pebble_ready("kubeflow-kfam")
+    harness.charm.on.install.emit()
+    harness.container_pebble_ready("kubeflow-profiles")
+    assert harness.charm.model.unit.status == ActiveStatus("")
 
 def test_profiles_pebble_layer(
     harness,  # noqa F811

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -72,40 +72,26 @@ def test_no_relation(
     assert harness.charm.model.unit.status == ActiveStatus("")
 
 
-def test_kfam_pebble_ready_first_scenario(
-    harness,  # noqa F811
-    mocked_kubernetes_service_patcher,  # noqa F811
-    mocked_resource_handler,  # noqa F811
-):
-    """Test kfam pebble ready then install then profiles pebble ready."""
-    harness.set_leader(True)
-    harness.begin()
-    harness.container_pebble_ready("kubeflow-kfam")
-    harness.charm.on.install.emit()
-    harness.container_pebble_ready("kubeflow-profiles")
-    assert harness.charm.model.unit.status == ActiveStatus("")
-
-
 def test_profiles_pebble_ready_first_scenario(
     harness,  # noqa F811
     mocked_kubernetes_service_patcher,  # noqa F811
     mocked_resource_handler,  # noqa F811
 ):
-    """Test profiles pebble ready then install then kfam pebble ready reach Active."""
+    """Test (install -> profiles pebble ready -> kfam pebble ready) reach Active.."""
     harness.set_leader(True)
     harness.begin()
-    harness.container_pebble_ready("kubeflow-profiles")
     harness.charm.on.install.emit()
+    harness.container_pebble_ready("kubeflow-profiles")
     harness.container_pebble_ready("kubeflow-kfam")
     assert harness.charm.model.unit.status == ActiveStatus("")
 
 
-def test_install_first_scenario(
+def test_kfam_pebble_ready_first_scenario(
     harness,  # noqa F811
     mocked_kubernetes_service_patcher,  # noqa F811
     mocked_resource_handler,  # noqa F811
 ):
-    """Test install then kfam pebble ready then profiles pebble ready reach Active."""
+    """Test (install -> kfam pebble ready -> profiles pebble ready) reach Active."""
     harness.set_leader(True)
     harness.begin()
     harness.charm.on.install.emit()


### PR DESCRIPTION
## Summary:
- simplified event handlers by removing update_container methods and deferred error handling to main method
- called main (on_event) method at the end of *_pebble_ready events
- replaced CheckFailed errors with ErrorWithStatus to be caught in main method