### PR TITLE
Refactor user creation action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,9 +1,9 @@
 create-profile:
-  description: Create a new profile under an existing user and apply configurations to the profile to allow using Minio, MLFlow, and Seldon.
+  description: Create a new profile under an authenticated user and apply configurations to the profile to allow using Minio, MLFlow, and Seldon.
   params:
     username:
       type: string
-      description: the name of the existing authenticated user under which the new profile will be added
+      description: the name of the authenticated user under which the new profile will be added
     profilename:
       type: string
       description: the name of the new profile to be created

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,21 +1,21 @@
 create-profile:
-  description: Create a new profile under an existing authenticated user and apply configurations to the profile.
+  description: Create a new profile under an existing user and apply configurations to the profile to allow using Minio, MLFlow, and Seldon.
   params:
-    authusername:
+    username:
       type: string
-      description: the username of the existing authenticated user
+      description: the name of the existing authenticated user under which the new profile will be added
     profilename:
       type: string
       description: the name of the new profile to be created
     resourcequota:
       type: string
       description: (Optional) resource quota for the new profile
-  required: [authusername, profilename]
+  required: [username, profilename]
 
 initialise-profile:
-  description: Apply configuration to an existing profile
+  description: Apply configuration to an existing profile to allow using Minio, MLFlow, and Seldon.
   params:
     profilename:
       type: string
-      description: the name of the new profile to be created
+      description: the name of the existing profile to be configured
   required: [profilename]

--- a/src/charm.py
+++ b/src/charm.py
@@ -285,16 +285,16 @@ class KubeflowProfilesOperator(CharmBase):
 
     def on_create_profile_action(self, event: ActionEvent) -> None:
         """Handle the action to create a new profile."""
-        auth_username = event.params.get("authusername")
+        username = event.params.get("username")
         profile_name = event.params.get("profilename")
         resource_quota = event.params.get("resourcequota")
         self.log.info(
-            f"Running action create-profile with parameters auth_username={auth_username}, profile_name={profile_name}, resource_quota={resource_quota}"  # noqa E501
+            f"Running action create-profile with parameters username={username}, profile_name={profile_name}, resource_quota={resource_quota}"  # noqa E501
         )
-        self.create_profile(auth_username, profile_name, resource_quota)
+        self.create_profile(username, profile_name, resource_quota)
         self.configure_profile(profile_name)
 
-    def create_profile(self, auth_username, profile_name, resource_quota):
+    def create_profile(self, username, profile_name, resource_quota):
         """Create new profile object."""
         formatted_quota = None
         if resource_quota:
@@ -319,7 +319,7 @@ class KubeflowProfilesOperator(CharmBase):
         my_profile = profile(
             metadata={"name": profile_name},
             spec={
-                "owner": {"kind": "User", "name": auth_username},
+                "owner": {"kind": "User", "name": username},
                 "resourceQuotaSpec": formatted_quota,
             },
         )
@@ -332,9 +332,6 @@ class KubeflowProfilesOperator(CharmBase):
         """Add missing configurations to profile."""
         create_global_resource(
             group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
-        )
-        create_global_resource(
-            group="kubeflow.org", version="v1alpha1", kind="PodDefault", plural="poddefaults"
         )
         # attempt to get namespace
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -292,6 +292,7 @@ class KubeflowProfilesOperator(CharmBase):
             f"Running action create-profile with parameters auth_username={auth_username}, profile_name={profile_name}, resource_quota={resource_quota}"  # noqa E501
         )
         self.create_profile(auth_username, profile_name, resource_quota)
+        self.configure_profile(profile_name)
 
     def create_profile(self, auth_username, profile_name, resource_quota):
         """Create new profile object."""
@@ -324,8 +325,6 @@ class KubeflowProfilesOperator(CharmBase):
         )
         self.k8s_resource_handler.lightkube_client.create(my_profile)
 
-        self.configure_profile(profile_name)
-
     def _load_text_to_dict(self, text):
         return json.loads(text)
 
@@ -333,6 +332,9 @@ class KubeflowProfilesOperator(CharmBase):
         """Add missing configurations to profile."""
         create_global_resource(
             group="kubeflow.org", version="v1", kind="Profile", plural="profiles"
+        )
+        create_global_resource(
+            group="kubeflow.org", version="v1alpha1", kind="PodDefault", plural="poddefaults"
         )
         # attempt to get namespace
         try:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -84,7 +84,7 @@ async def test_health_check_kfam(ops_test):
 async def test_create_profile_action(lightkube_client, ops_test):
     """Test profile creation action."""
     namespace = ops_test.model_name
-    auth_username = "admin"
+    username = "admin"
     profile_name = "myname"
     resource_quota = """
     {
@@ -103,14 +103,14 @@ async def test_create_profile_action(lightkube_client, ops_test):
         .units[0]
         .run_action(
             "create-profile",
-            authusername=auth_username,
+            username=username,
             profilename=profile_name,
             resourcequota=resource_quota,
         )
     )
     await action.wait()
     validate_profile_namespace(lightkube_client, profile_name)
-    validate_profile_owner(lightkube_client, namespace, profile_name, auth_username)
+    validate_profile_owner(lightkube_client, namespace, profile_name, username)
     validate_profile_resource_quota(lightkube_client, namespace, profile_name, expected_quota)
     validate_namespace_poddefaults(lightkube_client, profile_name)
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Secret
+from lightkube.generic_resource import create_global_resource
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, WaitingStatus
 
@@ -175,10 +176,13 @@ def test_on_create_profile_action(
                 }
         }
     """
+    create_global_resource(
+        group="kubeflow.org", version="v1alpha1", kind="PodDefault", plural="poddefaults"
+    )
     formatted_quota = json.loads(resource_quota)
     event = MagicMock(spec=ActionEvent)
     event.params = {
-        "authusername": auth_username,
+        "username": auth_username,
         "profilename": profile_name,
         "resourcequota": formatted_quota,
     }

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -4,9 +4,9 @@
 import json
 from unittest.mock import MagicMock, patch
 
+from lightkube.generic_resource import create_global_resource
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Secret
-from lightkube.generic_resource import create_global_resource
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, WaitingStatus
 


### PR DESCRIPTION
## Summary:

- call configure_profile in the action handler of create-profile instead of in the create_profile method to decouple them
- change action parameter name from authusername->username
- improve action and parameter descriptions