### PR TITLE
ci: add jira automation to create GH issues as jira card

### DIFF
--- a/.github/workflows/issues_to_jira.yaml
+++ b/.github/workflows/issues_to_jira.yaml
@@ -1,0 +1,17 @@
+# this workflow requires to provide JIRA webhook URL via JIRA_URL GitHub Secret
+# read more: https://support.atlassian.com/cloud-automation/docs/jira-automation-triggers/#Automationtriggers-Incomingwebhook
+# original code source: https://github.com/beliaev-maksim/github-to-jira-automation
+
+name: Issues to JIRA
+
+on:
+  issues:
+    # available via github.event.action
+    types: [opened, reopened, closed]
+
+jobs:
+  update:
+    name: Update Issue
+    uses: beliaev-maksim/github-to-jira-automation/.github/workflows/issues_to_jira.yaml@master
+    secrets:
+      JIRA_URL: ${{ secrets.JIRA_URL }}


### PR DESCRIPTION
Automation to create jira tasks from GitHub issues.