### PR TITLE
Fix: Profiles container entrypoint parameters

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -127,11 +127,7 @@ class KubeflowProfilesOperator(CharmBase):
                         "override": "replace",
                         "summary": "entry point for kubeflow profiles",
                         "command": (
-                            "/manager "
-                            "-userid-header "
-                            "kubeflow-userid "
-                            "-userid-prefix "
-                            '""'
+                            "/manager " "-userid-header " "kubeflow-userid " "-userid-prefix " '""'
                         ),
                         "startup": "enabled",
                     }

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,9 +131,7 @@ class KubeflowProfilesOperator(CharmBase):
                             "-userid-header "
                             "kubeflow-userid "
                             "-userid-prefix "
-                            " "
-                            "-workload-identity "
-                            " "
+                            '""'
                         ),
                         "startup": "enabled",
                     }

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -120,9 +120,7 @@ def test_profiles_pebble_layer(
         "-userid-header "
         "kubeflow-userid "
         "-userid-prefix "
-        " "
-        "-workload-identity "
-        " "
+        '""'
     )
 
 


### PR DESCRIPTION
## Context:
Issue https://github.com/canonical/notebook-operators/issues/210 came up in the pre-release testing of 1.7. The parameters of `/manager` in the entrypoint of `kubeflow-profiles` container were not going in as expected after the charm was rewritten to sidecar in  #46 
## Change in parameters:
### `userid-prefix`
- expected: `userid-prefix` should be an empty string `""`
- actual: `userid-prefix` was wrongly set to `-workload-identity` which should be the next parameter key,
we cannot leave this parameter to default since it defaults to `accounts.google.com:` for upstream reasons
### `workload-identity`
this can be removed as it defaults to `""` on upstream which is our expected behavior.

## Summary:
- remove workload-identity parameter that defaults to empty string
- correct syntax of userid-prefix to be empty string