### PR TITLE
fix: remove BlockedStatus statements in charm code

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -223,7 +223,12 @@ class KubeflowProfilesOperator(CharmBase):
 
     def _on_profiles_pebble_ready(self, event):
         """Update the started Profiles container."""
-        self._check_container_connection(self.profiles_container)
+        # TODO: extract exception handling to _check_container_connection()
+        try:
+            self._check_container_connection(self.profiles_container)
+        except ErrorWithStatus as error:
+            self.model.unit = error.status
+            return
         self._on_event(event)
 
     def _push_namespace_labels(self):
@@ -236,7 +241,11 @@ class KubeflowProfilesOperator(CharmBase):
 
     def _on_kfam_pebble_ready(self, event):
         """Update the started kfam container."""
-        self._check_container_connection(self.kfam_container)
+        try:
+            self._check_container_connection(self.kfam_container)
+        except ErrorWithStatus as error:
+            self.model.unit = error.status
+            return
         self._on_event(event)
 
     def _on_remove(self, event):

--- a/src/charm.py
+++ b/src/charm.py
@@ -8,7 +8,7 @@ import json
 import logging
 from pathlib import Path
 
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler as KRH  # noqa: N817
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charmed_kubeflow_chisme.pebble import update_layer
@@ -179,7 +179,7 @@ class KubeflowProfilesOperator(CharmBase):
             self.k8s_resource_handler.apply()
 
         except ApiError as e:
-            raise ApiError("Failed to create K8S resources") from e
+            raise GenericCharmRuntimeError("Failed to create K8S resources") from e
         self.model.unit.status = MaintenanceStatus("K8S resources created")
 
     def _check_container_connection(self, container: Container) -> None:
@@ -219,7 +219,7 @@ class KubeflowProfilesOperator(CharmBase):
                 self.log.info("Pebble plan updated with new configuration, replanning")
                 self.profiles_container.replan()
             except ChangeError as e:
-                raise ChangeError("Failed to replan") from e
+                raise GenericCharmRuntimeError("Failed to replan") from e
 
     def _on_profiles_pebble_ready(self, event):
         """Update the started Profiles container."""


### PR DESCRIPTION
A BlockedStatus mean a human has to manually intervene to ublock the unit and let it proceed. There were some conditions where no external intervention could ublock the unit. Adding appropriate logging and exceptions to catch errors and set status correctly.

Fixes canonical/bundle-kubeflow#549

Merge after #111 to fix CI issues.