### PR TITLE
feat: bump kfam and controller images to 1.8.0-rc.2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,12 +17,12 @@ resources:
     type: oci-image
     description: Profile controller image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.8.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.8.0-rc.2
   kfam-image:
     type: oci-image
     description: Access Management image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.8.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.8.0-rc.2
 provides:
   kubeflow-profiles:
     interface: k8s-service

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,6 +103,8 @@ class KubeflowProfilesOperator(CharmBase):
         """Return environment variables."""
         return {
             "ISTIO_INGRESS_GATEWAY_PRINCIPAL": "cluster.local/ns/kubeflow/sa/istio-ingressgateway-workload-service-account",  # noqa E501
+            "NOTEBOOK_CONTROLLER_PRINCIPAL": "cluster.local/ns/kubeflow/sa/jupyter-controller",
+            "KFP_UI_PRINCIPAL": "cluster.local/ns/kubeflow/sa/kfp-ui",
         }
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -99,6 +99,13 @@ class KubeflowProfilesOperator(CharmBase):
         return context
 
     @property
+    def service_environment(self):
+        """Return environment variables."""
+        return {
+            "ISTIO_INGRESS_GATEWAY_PRINCIPAL": "cluster.local/ns/kubeflow/sa/istio-ingressgateway-workload-service-account",  # noqa E501
+        }
+
+    @property
     def k8s_resource_handler(self):
         """Update K8S with K8S resources."""
         if not self._k8s_resource_handler:
@@ -128,6 +135,7 @@ class KubeflowProfilesOperator(CharmBase):
                         "command": (
                             "/manager " "-userid-header " "kubeflow-userid " "-userid-prefix " '""'
                         ),
+                        "environment": self.service_environment,
                         "startup": "enabled",
                     }
                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,6 +62,15 @@ class KubeflowProfilesOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._k8s_resource_handler = None
 
+        # service account names are hardcoded
+        # TODO: implement relation and get from relation data
+        # tracked in https://github.com/canonical/kubeflow-profiles-operator/issues/156
+        self._istio_gateway_principal = (
+            "cluster.local/ns/kubeflow/sa/istio-ingressgateway-workload-service-account"
+        )
+        self._notebook_controller_principal = "cluster.local/ns/kubeflow/sa/jupyter-controller"
+        self._kfp_ui_principal = "cluster.local/ns/kubeflow/sa/kfp-ui"
+
         # setup events to be handled by specific event handlers
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.remove, self._on_remove)
@@ -99,12 +108,20 @@ class KubeflowProfilesOperator(CharmBase):
         return context
 
     @property
-    def service_environment(self):
-        """Return environment variables."""
+    def _profiles_service_environment(self):
+        """Return environment variables for kubeflow-profiles container."""
         return {
-            "ISTIO_INGRESS_GATEWAY_PRINCIPAL": "cluster.local/ns/kubeflow/sa/istio-ingressgateway-workload-service-account",  # noqa E501
-            "NOTEBOOK_CONTROLLER_PRINCIPAL": "cluster.local/ns/kubeflow/sa/jupyter-controller",
-            "KFP_UI_PRINCIPAL": "cluster.local/ns/kubeflow/sa/kfp-ui",
+            "ISTIO_INGRESS_GATEWAY_PRINCIPAL": self._istio_gateway_principal,  # noqa E501
+            "NOTEBOOK_CONTROLLER_PRINCIPAL": self._notebook_controller_principal,
+            "KFP_UI_PRINCIPAL": self._kfp_ui_principal,
+        }
+
+    @property
+    def _kfam_service_environment(self):
+        """Return environment variables for kubeflow-kfam container."""
+        return {
+            "ISTIO_INGRESS_GATEWAY_PRINCIPAL": self._istio_gateway_principal,  # noqa E501
+            "KFP_UI_PRINCIPAL": self._kfp_ui_principal,
         }
 
     @property
@@ -137,7 +154,7 @@ class KubeflowProfilesOperator(CharmBase):
                         "command": (
                             "/manager " "-userid-header " "kubeflow-userid " "-userid-prefix " '""'
                         ),
-                        "environment": self.service_environment,
+                        "environment": self._profiles_service_environment,
                         "startup": "enabled",
                     }
                 },
@@ -169,6 +186,7 @@ class KubeflowProfilesOperator(CharmBase):
                             "-userid-prefix "
                             '""'
                         ),
+                        "environment": self._kfam_service_environment,
                         "startup": "enabled",
                     }
                 },


### PR DESCRIPTION
* closes https://github.com/canonical/notebook-operators/issues/309
* sets `ISTIO_INGRESS_GATEWAY_PRINCIPAL` env var in kubeflow-profiles and kubeflow-kfam containers
* sets the `KFP_UI_PRINCIPAL` env var in kubeflow-profiles and kubeflow-kfam containers
* sets the `NOTEBOOK_CONTROLLER_PRINCIPAL` env var in kubeflow-profiles container

Linked references where the env vars are used in [kubeflow-profiles container](https://github.com/kubeflow/kubeflow/blob/v1.8.0-rc.2/components/profile-controller/controllers/profile_controller.go#L420-L430) and [kubeflow-kfam container](https://github.com/kubeflow/kubeflow/blob/v1.8.0-rc.2/components/access-management/kfam/bindings.go#L80-L86)