### PR TITLE
Update manifests to v1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,12 +17,12 @@ resources:
     type: oci-image
     description: Profile controller image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.9.0-rc.0
   kfam-image:
     type: oci-image
     description: Access Management image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.9.0-rc.0
 provides:
   kubeflow-profiles:
     interface: k8s-service


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-profiles-operator/issues/165

I compared tags `v1.8.0` and `v1.9.0-rc.0` for these files https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller/config/overlays/kubeflow

Only the images have changed.