### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in main

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           provider: microk8s
           channel: 1.25-strict/stable
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
       - name: Run test
         run: |


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944