### PR TITLE
chore: bump kubeflow-profiles to v1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,12 +17,12 @@ resources:
     type: oci-image
     description: Profile controller image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.9.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.9.0
   kfam-image:
     type: oci-image
     description: Access Management image
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.9.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.9.0
 provides:
   kubeflow-profiles:
     interface: k8s-service


### PR DESCRIPTION
closes #175 
brings in the changes from https://github.com/kubeflow/manifests/tree/v1.9.0