### PR TITLE
Add alert rules to kubeflow-profiles based on the KF093 spec

### DIFF
--- a/src/prometheus_alert_rules/KubeflowProfilesServices.rules
+++ b/src/prometheus_alert_rules/KubeflowProfilesServices.rules
@@ -1,28 +1,6 @@
 groups:
-- name: KubeflowProfiles
+- name: KubeflowProfilesServices
   rules:
-  - alert: KfamDown
-    expr: absent(service_heartbeat{component="kfam"})
-    for: 5m
-    labels:
-      severity: critical
-    annotations:
-      summary: Kubeflow-kfam service is Down (instance {{ $labels.instance }})
-      description: |
-        The kubeflow-kfam service is unavailable.
-        LABELS = {{ $labels }}
-
-  - alert: ProfilesDown
-    expr: absent(service_heartbeat{component="profile_controller"})
-    for: 5m
-    labels:
-      severity: critical
-    annotations:
-      summary: Kubeflow-profiles service is Down (instance {{ $labels.instance }})
-      description: |
-        The kubeflow-profiles service is unavailable.
-        LABELS = {{ $labels }}
-
   - alert: KubeflowServiceDown
     expr: up{} < 1
     for: 5m


### PR DESCRIPTION
These alert rules provide an overview of all service states.

Using the KubeflowServiceDown or KubeflowServiceIsNotStable filter, the user
can easily see the status of all Kubeflow services.

part-of: [#1026](https://github.com/canonical/bundle-kubeflow/issues/1026)
