### PR TITLE
fix: update create-profile action description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Charmed Kubeflow Profiles
-=========================
-Charmed Kubeflow Profiles is the charm that implements the Kubeflow profile controller, which manages [user Profiles](https://charmed-kubeflow.io/docs/profile).  These Profiles enable [Kubeflow Multi-Tenancy](https://www.kubeflow.org/docs/components/multi-tenancy/) to allow for multi-user isolation.
+# Charmed Kubeflow Profiles
+Charmed Kubeflow Profiles is the charm that implements the Kubeflow profile controller, which manages user Profiles. These Profiles enable [Kubeflow Multi-Tenancy](https://www.kubeflow.org/docs/concepts/multi-tenancy/) to allow for multi-user isolation. For more information on managing profiles, refer to the relevant Charmed Kubeflow [documentation](https://charmed-kubeflow.io/docs/manage-profiles).
+

--- a/actions.yaml
+++ b/actions.yaml
@@ -9,7 +9,7 @@ create-profile:
       description: the name of the new profile to be created
     resourcequota:
       type: string
-      description: (Optional) resource quota for the new profile
+      description: (Optional) resource quota for the new profile. This must be used in combination with the argument `--string args`.
   required: [username, profilename]
 
 initialise-profile:


### PR DESCRIPTION
Update create-profile action description to let users know that `resource-quota` argument must always be used in combination the extra argument `--string-args`. This is reflected the charm's charmhub page [here](https://charmhub.io/kubeflow-profiles/actions?channel=latest/edge).

Fix #205

Note that this will be backported to `track/1.9`