### PR TITLE
chore: update profile-controller and kfam images 1.9.0 -> 1.10.0-rc.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,12 +17,12 @@ resources:
     type: oci-image
     description: Profile controller image
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/profile-controller:1.9.0-9e28e0c
+    upstream-source: docker.io/kubeflownotebookswg/profile-controller:v1.10.0-rc.0
   kfam-image:
     type: oci-image
     description: Access Management image
     auto-fetch: true
-    upstream-source: docker.io/charmedkubeflow/kfam:1.9.0-afd96fb
+    upstream-source: docker.io/kubeflownotebookswg/kfam:v1.10.0-rc.0
 provides:
   kubeflow-profiles:
     interface: k8s-service


### PR DESCRIPTION
Use upstream image and updates the version of the oci-images used for kfam and the profile-controller.

These components did not receive any updates in terms of manifests, so for them to be updated, we just need to use the latest images for the 1.10.0-rc.0 version. See https://github.com/kubeflow/manifests/pull/2995 for reference.