### PR TITLE
tests: Move charms-dependencies in dependencies.py

### DIFF
--- a/tests/integration/dependencies.py
+++ b/tests/integration/dependencies.py
@@ -1,0 +1,5 @@
+"""Charm dependencies for tests."""
+
+ISTIO_PILOT = "istio-pilot"
+ISTIO_PILOT_CHANNEL = "1.24/stable"
+ISTIO_PILOT_TRUST = True

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,6 +15,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from dependencies import ISTIO_PILOT, ISTIO_PILOT_CHANNEL, ISTIO_PILOT_TRUST
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace
@@ -26,10 +27,6 @@ log = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
-ADMISSION_WEBHOOK_NAME = "admission-webhook"
-ISTIO_PILOT_NAME = "istio-pilot"
-ISTIO_PILOT_CHANNEL = "1.24/stable"
-ISTIO_PILOT_TRUST = True
 
 
 @pytest.mark.abort_on_fail
@@ -50,7 +47,7 @@ async def test_build_and_deploy(ops_test):
     # The profile controller needs AuthorizationPolicies to create Profiles
     # Let's just deploy istio-pilot to provide the k8s cluster with this CRD
     await ops_test.model.deploy(
-        entity_url=ISTIO_PILOT_NAME,
+        entity_url=ISTIO_PILOT,
         channel=ISTIO_PILOT_CHANNEL,
         trust=ISTIO_PILOT_TRUST,
     )


### PR DESCRIPTION
Keep charms-dependencies that are deployed during integration in a distinct
dependencies.py file to enable managing them automatically.

Ref canonical/bundle-kubeflow#1256
