### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -38,7 +38,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -67,7 +67,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -1,0 +1,5 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -15,6 +15,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from charms_dependencies import ISTIO_PILOT
 from lightkube import codecs
 from lightkube.generic_resource import create_global_resource
 from lightkube.resources.core_v1 import Namespace
@@ -26,10 +27,6 @@ log = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
-ADMISSION_WEBHOOK_NAME = "admission-webhook"
-ISTIO_PILOT_NAME = "istio-pilot"
-ISTIO_PILOT_CHANNEL = "1.24/stable"
-ISTIO_PILOT_TRUST = True
 
 
 @pytest.mark.abort_on_fail
@@ -50,9 +47,9 @@ async def test_build_and_deploy(ops_test):
     # The profile controller needs AuthorizationPolicies to create Profiles
     # Let's just deploy istio-pilot to provide the k8s cluster with this CRD
     await ops_test.model.deploy(
-        entity_url=ISTIO_PILOT_NAME,
-        channel=ISTIO_PILOT_CHANNEL,
-        trust=ISTIO_PILOT_TRUST,
+        entity_url=ISTIO_PILOT.charm,
+        channel=ISTIO_PILOT.channel,
+        trust=ISTIO_PILOT.trust,
     )
 
     # Deploying grafana-agent-k8s and add all relations


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
