### PR TITLE
fix: Change dump-charm-debug-artifacts to run on failure

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -83,4 +83,4 @@ jobs:
 
       - name: Save debug artifacts
         uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        if: always()
+        if: failure()


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1341