### PR TITLE
fix: update charm status correctly

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -270,7 +270,7 @@ class KubeflowProfilesOperator(CharmBase):
     def _deploy_k8s_resources(self):
         """Deploy K8S resources."""
         try:
-            self.unit.status = MaintenanceStatus("Creating K8S resources")
+            self.model.unit.status = MaintenanceStatus("Creating K8S resources")
             self.k8s_resource_handler.apply()
 
         except ApiError as e:
@@ -327,10 +327,10 @@ class KubeflowProfilesOperator(CharmBase):
         # TODO: extract exception handling to _check_container_connection()
         try:
             self._check_container_connection(self.profiles_container)
+            self._check_profiles_container_storage()
         except ErrorWithStatus as error:
-            self.model.unit = error.status
+            self.model.unit.status = error.status
             return
-        self._check_profiles_container_storage()
         self._on_event(event)
 
     def _update_profile_namespace_security_policy_labels(self):
@@ -364,7 +364,7 @@ class KubeflowProfilesOperator(CharmBase):
         try:
             self._check_container_connection(self.kfam_container)
         except ErrorWithStatus as error:
-            self.model.unit = error.status
+            self.model.unit.status = error.status
             return
         self._on_event(event)
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,11 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Unit tests. Harness and Mocks are defined in test_operator_fixtures.py."""
-from re import match
 from unittest.mock import ANY, patch
 
 import pytest
-from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
@@ -64,16 +62,10 @@ def test_storage_not_available(
     storage_id = harness.charm.model.storages["config-profiles"][0].full_id
     # remove storage so that the storage check fails
     harness.remove_storage(storage_id)
-
-    with pytest.raises(ErrorWithStatus) as exception_info:
-        # trigger the event that evokes the storage check
-        harness.container_pebble_ready(WORKLOAD_CONTAINER_NAME_FOR_PROFILES)
-
-        # assert the exception and the charm status are as expected
-        assert exception_info.value.status_type(WaitingStatus)
-        assert match("Storage .* not yet available on path .*", str(exception_info))
-        assert isinstance(harness.charm.model.unit.status, WaitingStatus)
-        assert "Waiting for storage" in harness.charm.model.unit.status.message
+    # trigger the event that evokes the storage check
+    harness.container_pebble_ready(WORKLOAD_CONTAINER_NAME_FOR_PROFILES)
+    # assert the the charm status is as expected
+    assert harness.charm.model.unit.status == WaitingStatus("Waiting for storage")
 
 
 @pytest.mark.parametrize("invalid_port", [80, 100000])


### PR DESCRIPTION
While working on https://github.com/canonical/notebook-operators/pull/527, I've realized that in the previous pull request of mine to this repository, https://github.com/canonical/kubeflow-profiles-operator/pull/281, with [this test](https://github.com/canonical/kubeflow-profiles-operator/blob/main/tests/unit/test_operator.py#L55)...
```python
def test_storage_not_available(
    harness: Harness,
    mocked_kubernetes_service_patcher,
    mocked_resource_handler,
):
    """Test storage not available scenario."""
    # begin() is required to access charm attribute of harness
    harness.begin()
    # retrieve first (and only) storage ID for config-profiles storage
    storage_id = harness.charm.model.storages["config-profiles"][0].full_id
    # remove storage so that the storage check fails
    harness.remove_storage(storage_id)

    with pytest.raises(ErrorWithStatus) as exception_info:
        # trigger the event that evokes the storage check
        harness.container_pebble_ready(WORKLOAD_CONTAINER_NAME_FOR_PROFILES)

        # assert the exception and the charm status are as expected
        assert exception_info.value.status_type(WaitingStatus)
        assert match("Storage .* not yet available on path .*", str(exception_info))
        assert isinstance(harness.charm.model.unit.status, WaitingStatus)
        assert "Waiting for storage" in harness.charm.model.unit.status.message
```
...I was accidentally skipping assertions after the exception raising was verified by Pytest because, [as explained in Pytest's docs](https://docs.pytest.org/en/7.1.x/how-to/assert.html#assertions-about-expected-exceptions), I was not executing them outside the context manager and the context manager exits as soon as the exception is verified. In other words, a similar change was necessary for any final exception:
```diff
with pytest.raises(ErrorWithStatus) as exception_info:
    # ...triggering the exception...
-   assert exception_info.value.status_type(WaitingStatus)
+assert exception_info.value.status_type(WaitingStatus)
```

This made me start to fix unit tests with this pull request and, while doing, so, I also realized the status of the charm was not correctly set, and that it was a broader problem that involved other charm logic pieces in addition to the ones covered by the unit test. So this pull request ended up addressing these problems in setting the charm status correctly, following [what suggested in Chisme's docs](https://github.com/canonical/charmed-kubeflow-chisme/tree/main/src/charmed_kubeflow_chisme/exceptions#errorwithstatus), and accordingly updating the original test one more time because no exception is to be raised.