### PR TITLE
fix: update service heartbeat metrics according to new suffix

### DIFF
--- a/src/prometheus_alert_rules/KubeflowProfilesServices.rules
+++ b/src/prometheus_alert_rules/KubeflowProfilesServices.rules
@@ -2,7 +2,7 @@ groups:
 - name: KubeflowProfiles
   rules:
   - alert: KfamDown
-    expr: absent(service_heartbeat{component="kfam"})
+    expr: absent(service_heartbeat_total{component="kfam"})
     for: 5m
     labels:
       severity: critical
@@ -13,7 +13,7 @@ groups:
         LABELS = {{ $labels }}
 
   - alert: ProfilesDown
-    expr: absent(service_heartbeat{component="profile_controller"})
+    expr: absent(service_heartbeat_total{component="profile_controller"})
     for: 5m
     labels:
       severity: critical


### PR DESCRIPTION
Latest versions of OpenTelemetry Collector include by default a `_total` suffix for counters.

From OpenTelemetry Collector, the scraped metrics is this:
```
# HELP service_heartbeat Heartbeat signal every 10 seconds indicating pods are alive.
# TYPE service_heartbeat counter
service_heartbeat{component="profile_controller",severity="critical"} 5
```

From Prometheus Server in COS however the label is renamed in `service_heartbeat_total` as can be seen by querying the available labels:
```
$ curl -X GET http://localhost:9090/api/v1/label/__name__/values | jq .
{
  [
     ...
     "service_heartbeat_total",
     ...
  ]
}
```
The metric is indeed the correct one:
```
$ curl -sX GET http://localhost:9090/api/v1/query?query=service_heartbeat_total | jq .
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "service_heartbeat_total",
          "component": "profile_controller",
          "instance": "kubeflow_3ddb8c14-fa03-44bd-84ed-2bd1bfde1048_kubeflow-profiles_kubeflow-profiles/0",
          "job": "juju_kubeflow_3ddb8c14_kubeflow-profiles_prometheus_scrape-0",
          "juju_application": "kubeflow-profiles",
          "juju_charm": "kubeflow-profiles",
          "juju_model": "kubeflow",
          "juju_model_uuid": "3ddb8c14-fa03-44bd-84ed-2bd1bfde1048",
          "juju_unit": "kubeflow-profiles/0",
          "severity": "critical"
        },
        "value": [
          1778232219.052,
          "198"
        ]
      },
      {
        "metric": {
          "__name__": "service_heartbeat_total",
          "component": "kfam",
          "instance": "kubeflow_3ddb8c14-fa03-44bd-84ed-2bd1bfde1048_kubeflow-profiles_kubeflow-profiles/0",
          "job": "juju_kubeflow_3ddb8c14_kubeflow-profiles_prometheus_scrape-0",
          "juju_application": "kubeflow-profiles",
          "juju_charm": "kubeflow-profiles",
          "juju_model": "kubeflow",
          "juju_model_uuid": "3ddb8c14-fa03-44bd-84ed-2bd1bfde1048",
          "juju_unit": "kubeflow-profiles/0",
          "severity": "critical"
        },
        "value": [
          1778232219.052,
          "198"
        ]
      }
    ]
  }
}
```

This PR updates the alert rules to reflect this change.

Reference discussion: https://github.com/open-telemetry/opentelemetry-collector/issues/12458