### PR TITLE
chore: pin charm dependencies in tests (track/2.0)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -2,5 +2,5 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="latest/edge", trust=True)
-KUBEFLOW_DASHBOARD = CharmSpec(charm="kubeflow-dashboard", channel="latest/edge", trust=True)
+ISTIO_PILOT = CharmSpec(charm="istio-pilot", channel="1.28/edge", trust=True)
+KUBEFLOW_DASHBOARD = CharmSpec(charm="kubeflow-dashboard", channel="2.0/edge", trust=True)


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track) — entries marked _(override)_ are pinned via `config.FALLBACK_OVERRIDES`
- `istio-pilot`: `latest/edge` → `1.28/edge`
- `kubeflow-dashboard`: `latest/edge` → `2.0/edge` _(override)_

Refs: canonical/bundle-kubeflow#1379
